### PR TITLE
Use same color as in flyers

### DIFF
--- a/style.css
+++ b/style.css
@@ -111,7 +111,7 @@ body > .pure-g {
 }
 
 body > .pure-g:nth-child(2n) {
-    background-color: #85947e;
+    background-color: #8BA915;
     color: #ffffff;
 }
 
@@ -200,7 +200,7 @@ pre {
 }
 
 .line {
-    background: #85947e;
+    background: #8BA915;
     margin: -10% -1% 10%;
     padding-top: 11%;
     position: relative;


### PR DESCRIPTION
Uses then the same color as on the flyers:

![bildschirmfoto am 2017-09-23 um 14 25 30-fullpage](https://user-images.githubusercontent.com/245432/30773157-1e601892-a06b-11e7-92d3-7c1f785800bc.png)
